### PR TITLE
Use <img> in slideshow for other image extensions than .svg

### DIFF
--- a/src/slideshow.svelte
+++ b/src/slideshow.svelte
@@ -7,11 +7,11 @@ let current = 0;
 </script>
 
 <style>
-  object {
+  img, object {
     display: none;
     height: 100%;
   }
-  object.active {
+  img.active, object.active {
     display: block;
   }
   button {
@@ -38,7 +38,11 @@ let current = 0;
 
   <div style="height: 100%;">
   {#each {length: parseInt(to) - parseInt(from) + 1} as _, num}
-    <object data="{src}{num}.{extension}" class:active={current === num}></object>
+    {#if extension === "svg"}
+      <object data="{src}{num}.{extension}" class:active={current === num}></object>
+    {:else}
+      <img src="{src}{num}.{extension}" class:active={current === num} />
+    {/if}
   {/each}
   </div>
 </div>


### PR DESCRIPTION
In https://github.com/mrlvsb/upr-exercises/pull/1 added support for bitmap images in Slideshow. I kept the `<object>` tag so that SVGs are not turned into a bitmap and you could copy text out of them etc.

But for bitmap images, `<object>` keeps "flashing" and downloads the images lazily, which doesn't provide a good UI.